### PR TITLE
Fixes various issues in security/tpm2-abrmd

### DIFF
--- a/security/tpm2-abrmd/Makefile
+++ b/security/tpm2-abrmd/Makefile
@@ -17,7 +17,7 @@ RUN_DEPENDS=	dbus-daemon:devel/dbus
 USES=		gmake libtool pkgconfig gnome
 USE_LDCONFIG=	yes
 USE_GNOME=	glib20
-USE_RC_SUBR=	tpm2-abrmd
+USE_RC_SUBR=	tpm2_abrmd
 
 GNU_CONFIGURE=	yes
 GNU_CONFIGURE_MANPREFIX=${PREFIX}/share
@@ -27,9 +27,6 @@ GROUPS=		_tss
 USERS=		_tss
 
 SUB_LIST=	DBUS_DAEMON=dbus
-
-pre-install:
-	@${INSTALL_DATA} ${FILESDIR}/tpm2-abrmd-devd.conf ${STAGEDIR}${PREFIX}/etc/devd
 
 post-install:
 	@${RM} ${STAGEDIR}${PREFIX}/lib/systemd/system-preset/tpm2-abrmd.preset

--- a/security/tpm2-abrmd/files/patch-dist_tpm2-abrmd.conf
+++ b/security/tpm2-abrmd/files/patch-dist_tpm2-abrmd.conf
@@ -1,25 +1,37 @@
 --- dist/tpm2-abrmd.conf.orig	2022-05-09 15:39:53 UTC
 +++ dist/tpm2-abrmd.conf
-@@ -2,7 +2,7 @@
+@@ -2,27 +2,25 @@
   "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
  <busconfig>
    <!-- ../system.conf have denied everything, so we just punch some holes -->
 -  <policy user="tss">
-+  <policy user="_tss">
-     <allow own="com.intel.tss2.Tabrmd"/>
-   </policy>
+-    <allow own="com.intel.tss2.Tabrmd"/>
+-  </policy>
+-  <policy user="root">
+-    <allow own="com.intel.tss2.Tabrmd"/>
+-  </policy>
+   <!-- Match /dev/tpmrm0 permissions tss tss 0660 -->
    <policy user="root">
-@@ -17,11 +17,11 @@
      <allow send_destination="com.intel.tss2.Tabrmd"/>
      <allow receive_sender="com.intel.tss2.Tabrmd"/>
++    <allow own="com.intel.tss2.Tabrmd"/>
+   </policy>
+-  <policy group="root">
++  <policy group="wheel">
+     <allow send_destination="com.intel.tss2.Tabrmd"/>
+     <allow receive_sender="com.intel.tss2.Tabrmd"/>
++    <allow own="com.intel.tss2.Tabrmd"/>
    </policy>
 -  <policy user="tss">
 +  <policy user="_tss">
      <allow send_destination="com.intel.tss2.Tabrmd"/>
      <allow receive_sender="com.intel.tss2.Tabrmd"/>
++    <allow own="com.intel.tss2.Tabrmd"/>
    </policy>
 -  <policy group="tss">
 +  <policy group="_tss">
      <allow send_destination="com.intel.tss2.Tabrmd"/>
      <allow receive_sender="com.intel.tss2.Tabrmd"/>
++    <allow own="com.intel.tss2.Tabrmd"/>
    </policy>
+ </busconfig>

--- a/security/tpm2-abrmd/files/patch-src_response-sink.c
+++ b/security/tpm2-abrmd/files/patch-src_response-sink.c
@@ -1,0 +1,11 @@
+--- src/response-sink.c.orig	2025-02-22 21:59:15 UTC
++++ src/response-sink.c
+@@ -188,7 +188,7 @@ response_sink_process_response (Tpm2Response *response
+ 
+     g_debug ("%s: writing 0x%x bytes", __func__, size);
+     g_debug_bytes (buffer, size, 16, 4);
+-    written = write_all (ostream, buffer, size);
++    written = g_write_all (ostream, buffer, size);
+     g_object_unref (connection);
+ 
+     return written;

--- a/security/tpm2-abrmd/files/patch-src_tcti-tabrmd.c
+++ b/security/tpm2-abrmd/files/patch-src_tcti-tabrmd.c
@@ -1,0 +1,11 @@
+--- src/tcti-tabrmd.c.orig	2025-02-22 21:59:15 UTC
++++ src/tcti-tabrmd.c
+@@ -46,7 +46,7 @@ tss2_tcti_tabrmd_transmit (TSS2_TCTI_CONTEXT *context,
+     g_debug_bytes (command, size, 16, 4);
+     ostream = g_io_stream_get_output_stream (TSS2_TCTI_TABRMD_IOSTREAM (context));
+     g_debug ("%s: blocking write on ostream", __func__);
+-    write_ret = write_all (ostream, command, size);
++    write_ret = g_write_all (ostream, command, size);
+     /* should switch on possible errors to translate to TSS2 error codes */
+     switch (write_ret) {
+     case -1:

--- a/security/tpm2-abrmd/files/patch-src_util.c
+++ b/security/tpm2-abrmd/files/patch-src_util.c
@@ -1,0 +1,30 @@
+--- src/util.c.orig	2025-02-22 21:59:15 UTC
++++ src/util.c
+@@ -68,7 +68,7 @@ ssize_t
+ /** Write as many of the size bytes from buf to fd as possible.
+  */
+ ssize_t
+-write_all (GOutputStream *ostream,
++g_write_all (GOutputStream *ostream,
+            const uint8_t *buf,
+            const size_t   size)
+ {
+@@ -77,14 +77,15 @@ write_all (GOutputStream *ostream,
+     GError *error = NULL;
+ 
+     do {
+-        g_debug ("%s: writing %zu bytes to ostream", __func__,
+-                 size - written_total);
++        g_debug ("%s: writing %zu bytes to ostream from %zu", __func__,
++                 size - written_total, buf);
+         written = g_output_stream_write (ostream,
+                                          (const gchar*)&buf [written_total],
+                                          size - written_total,
+                                          NULL,
+                                          &error);
+-        switch (written) {
++        g_debug ("Passed");
++	switch (written) {
+         case -1:
+             g_assert (error != NULL);
+             g_warning ("%s: failed to write to ostream: %s", __func__, error->message);

--- a/security/tpm2-abrmd/files/patch-src_util.h
+++ b/security/tpm2-abrmd/files/patch-src_util.h
@@ -1,0 +1,11 @@
+--- src/util.h.orig	2025-02-22 21:59:15 UTC
++++ src/util.h
+@@ -79,7 +79,7 @@ typedef TSS2_RC (*KeyValueFunc) (const key_value_t* ke
+ #define TPMA_CC_RES(attrs)         (attrs.val & 0xc0000000)
+ */
+ 
+-ssize_t     write_all                       (GOutputStream    *ostream,
++ssize_t     g_write_all                       (GOutputStream    *ostream,
+                                              const uint8_t    *buf,
+                                              const size_t      size);
+ int         read_data                       (GInputStream     *istream,

--- a/security/tpm2-abrmd/pkg-message
+++ b/security/tpm2-abrmd/pkg-message
@@ -1,0 +1,10 @@
+[
+{ type: install
+  message: <<EOM
+Please add the following lines to /etc/devfs.conf as tpm2-abrmd needs /dev/tpm0
+to be mode 0660 and group _tss:
+perm	tpm0	0660
+own	tpm0	root:_tss
+EOM
+}
+]

--- a/security/tpm2-abrmd/pkg-plist
+++ b/security/tpm2-abrmd/pkg-plist
@@ -1,6 +1,5 @@
 include/tss2/tss2-tcti-tabrmd.h
 etc/dbus-1/system.d/tpm2-abrmd.conf
-etc/devd/tpm2-abrmd-devd.conf
 lib/libtss2-tcti-tabrmd.a
 lib/libtss2-tcti-tabrmd.so
 lib/libtss2-tcti-tabrmd.so.0


### PR DESCRIPTION
Issue #1: Name collision on function write_all():

This port in file tpm2-abrmd-3.0.0/src/util.h at line 82 declares a function "ssize_t write_all(GOutputStream *ostream, const uint8_t *buf, const size_t size);", implemented in work/tpm2-abrmd-3.0.0/src/util.c. 
The tpm2-abrmd, at runtime, when trying to access directly the device /dev/tpm0, loads dynamically [using dlopen()] the library /usr/local/lib/libtss2-tcti-device.so.0.0.0 provided by port security/tpm2-tss, 
The function write_all() is implemented by port security/tpm2-tss in file src/util/io.c at line 85 with prototype "ssize_t write_all(SOCKET fd, const uint8_t *buf, size_t size)".
Basically the two functions do the same thing, but the one in tpm2-abrmd takes as first parameter a GOutputStream while the one in tpm2-tss expects a file descriptor; at runtime the wrong function gets called and this causes a coredump. 
As the function in tpm2-abrmd acts on a GOutputStream, the most sane approach seems to be prepending a g_ to its name, avoiding the name clash. 
The issue is likely triggered by the fact that the library libtss2-tcti-device.so.0.0.0 is not loaded by the linker, but explicitly.

Issue #2: tpm2-abrmd-devd.conf is useless and does not work

The port installs a tpm2-abrmd-devd.conf in /usr/local/etc/ aimed at fixing the ownership and permission of /dev/tpm0 
This does not work: /dev/tpm0 (if available) is created by the kernel at an early boot stage, devd does not get any notification. 
The proper place to fix the permissions and ownership of the device is /etc/devfs.conf, as it does not look like a great idea to programmatically change a file in /etc I added, as most ports to in these cases, a message to the sysadmin asking to do it.

Issue #3: We do not have a group named "root"

The port installs a /usr/local/etc/dbus-1/system.d/tpm2-abrmd.conf a policy giving permissions to a group name "root". 
Unix does not have a group named "root", gid 0 is named "wheel"; fixed.

Issue #4: Inconsistent naming of /usr/local/etc/rc.d/tpm2-abrmd

The program name, unfortunately contains a dash (tpm2-abrmd), which is not sane in rc scripts; the provided rc script correctly uses the service name "tpm2_abrmd". 
Still, the script filename is "tpm2-abrmd", while docs at https://docs.freebsd.org/en/articles/rc-scripting/ clearly state "The content of the name variable needs to match the script name".
I renamed the script tpm2_abrmd, as I could not rename the service to tpm2-abrmd ["the filename shall also not contain characters which may be troublesome in scripting (e.g., do not use a hyphen "-" and others)"].